### PR TITLE
미터기 게이지 투명도 옵션 추가

### DIFF
--- a/src/main/resources/src/components/MeterRow.tsx
+++ b/src/main/resources/src/components/MeterRow.tsx
@@ -40,6 +40,7 @@ export const MeterRow = memo(
     const nameDisplay = useSettingsStore((s) => s.nameDisplay);
     const theme = useSettingsStore((s) => s.theme);
     const showPower = useSettingsStore((s) => s.showPower);
+    const meterOpacity = useSettingsStore((s) => s.meterOpacity);
 
     const gradients = {
       user: makeGradient(...theme.userBar),
@@ -60,6 +61,7 @@ export const MeterRow = memo(
     const fontSize = `${Math.max(10, Math.floor(rowHeight * 0.4))}px`;
 
     const ratio = Math.max(0, Math.min(1, dps / topDps));
+    const gaugeOpacity = meterOpacity / 100;
     const iconSrc = getJobIconSrc(job);
     const fillGradient = isUser
       ? gradients.user
@@ -183,6 +185,7 @@ export const MeterRow = memo(
           className="absolute inset-0 origin-left transition-transform duration-150 ease-out"
           style={{
             background: fillGradient,
+            opacity: gaugeOpacity,
             transform: `scaleX(${ratio})`,
           }}
         />

--- a/src/main/resources/src/components/TargetInfo.tsx
+++ b/src/main/resources/src/components/TargetInfo.tsx
@@ -1,6 +1,7 @@
 import { memo } from "react";
 import bossIcon from "@/assets/bossIcon.png";
 import { useSettingsStore } from "@/stores/useSettingsStore";
+
 interface Props {
   targetName: string;
   rowHeight: number;
@@ -9,11 +10,13 @@ interface Props {
 
 export const TargetInfo = memo(({ targetName, rowHeight, remainHp }: Props) => {
   const theme = useSettingsStore((s) => s.theme);
+  const meterOpacity = useSettingsStore((s) => s.meterOpacity);
   const displayName = targetName || "타겟 인식 실패";
   const isFailed = !targetName;
 
   const iconSize = Math.round(rowHeight * 0.7);
   const fontSize = `${Math.max(10, Math.round(rowHeight * 0.4))}px`;
+  const meterGaugeOpacity = meterOpacity / 100;
 
   return (
     <div
@@ -23,7 +26,7 @@ export const TargetInfo = memo(({ targetName, rowHeight, remainHp }: Props) => {
         className="absolute inset-0 origin-left"
         style={{
           background: `linear-gradient(to right, ${theme.bossBar[0]}, ${theme.bossBar[1]})`,
-          opacity: isFailed ? 0.2 : 0.8,
+          opacity: (isFailed ? 0.2 : 0.8) * meterGaugeOpacity,
         }}
       />
       <div className="relative h-full flex items-center gap-3">

--- a/src/main/resources/src/components/panels/SettingsPanel.tsx
+++ b/src/main/resources/src/components/panels/SettingsPanel.tsx
@@ -82,6 +82,8 @@ export const SettingsPanel = ({
     setNameDisplay,
     fontFamily,
     setFontFamily,
+    meterOpacity,
+    setMeterOpacity,
     rowHeight,
     setRowHeight,
     isMinimal,
@@ -111,6 +113,7 @@ export const SettingsPanel = ({
     headerPosition,
     nameDisplay,
     fontFamily,
+    meterOpacity,
     rowHeight,
     isMinimal,
     theme: { ...theme },
@@ -121,10 +124,11 @@ export const SettingsPanel = ({
   }, []);
 
   const handleChange = (
-    partial: Partial<{ displayMode: DisplayMode; nameDisplay: NameDisplay; rowHeight: number }>,
+    partial: Partial<{ displayMode: DisplayMode; nameDisplay: NameDisplay; meterOpacity: number; rowHeight: number; }>,
   ) => {
     if (partial.displayMode !== undefined) setDisplayMode(partial.displayMode);
     if (partial.nameDisplay !== undefined) setNameDisplay(partial.nameDisplay);
+    if (partial.meterOpacity !== undefined) setMeterOpacity(partial.meterOpacity);
     if (partial.rowHeight !== undefined) setRowHeight(partial.rowHeight);
   };
 
@@ -138,6 +142,7 @@ export const SettingsPanel = ({
     setDisplayMode(snapshot.displayMode);
     setNameDisplay(snapshot.nameDisplay);
     setFontFamily(snapshot.fontFamily);
+    setMeterOpacity(snapshot.meterOpacity);
     setRowHeight(snapshot.rowHeight);
     setIsMinimal(snapshot.isMinimal);
     setHotkey(snapshot.hotkey);
@@ -243,11 +248,13 @@ export const SettingsPanel = ({
             </Select>
           </SettingsRow>
         </SettingsItem>
+
         <div className="my-3 flex items-center gap-2">
           <div className="flex-1 h-px bg-white/10" />
           <span className="text-xs opacity-40 px-2 shrink-0">단축키 설정</span>
           <div className="flex-1 h-px bg-white/10" />
         </div>
+
         <SettingsItem>
           <SettingsRow
             title="새로고침"
@@ -275,6 +282,7 @@ export const SettingsPanel = ({
             />
           </SettingsRow>
         </SettingsItem>
+
         <div className="my-3 flex items-center gap-2">
           <div className="flex-1 h-px bg-white/10" />
           <span className="text-xs opacity-40 px-2 shrink-0">미터기 설정</span>
@@ -347,9 +355,27 @@ export const SettingsPanel = ({
                 step={1}
                 className="cursor-pointer"
                 value={[rowHeight]}
-                onValueChange={(value) => handleChange({ rowHeight: value[0] })}
+                onValueChange={(v) => handleChange({ rowHeight: v[0] })}
               />
               <span className="text-xs opacity-60 w-12 text-right tabular-nums">{rowHeight}px</span>
+            </div>
+          </SettingsRow>
+
+          <SettingsRow
+            title="투명도 설정"
+            description="미터기 투명도 값을 저장합니다"
+            align="center"
+            rightClassName="w-44">
+            <div className="flex h-8 items-center gap-3">
+              <Slider
+                min={10}
+                max={100}
+                step={1}
+                className="cursor-pointer"
+                value={[meterOpacity]}
+                onValueChange={(v) => handleChange({ meterOpacity: v[0] })}
+              />
+              <span className="text-xs opacity-60 w-12 text-right tabular-nums">{meterOpacity}%</span>
             </div>
           </SettingsRow>
         </SettingsItem>
@@ -360,6 +386,7 @@ export const SettingsPanel = ({
           <span className="text-xs opacity-40 px-2 shrink-0">테마 설정</span>
           <div className="flex-1 h-px bg-white/10" />
         </div>
+
         <SettingsItem title="유저 이름 색상">
           <div className="flex flex-col gap-2.5">
             <ColorSwatch
@@ -379,6 +406,7 @@ export const SettingsPanel = ({
             /> */}
           </div>
         </SettingsItem>
+
         <SettingsItem title="미터 바 색상">
           <div className="flex flex-col gap-2.5">
             <GradientRow

--- a/src/main/resources/src/stores/useSettingsStore.ts
+++ b/src/main/resources/src/stores/useSettingsStore.ts
@@ -48,6 +48,9 @@ export const DEFAULT_THEME: ThemeColors = {
   bossRightValue: "#e63333",
 };
 
+const MIN_METER_OPACITY = 10;
+const MAX_METER_OPACITY = 100;
+
 interface SettingsState {
   hotkey: Hotkey;
   displayMode: DisplayMode;
@@ -58,6 +61,8 @@ interface SettingsState {
   setFontFamily: (v: FontFamily) => void;
   meterWidth: number;
   setMeterWidth: (w: number) => void;
+  meterOpacity: number;
+  setMeterOpacity: (value: number) => void;
   rowHeight: number;
   setRowHeight: (h: number) => void;
   detailWidth: number;
@@ -93,6 +98,7 @@ const defaultSettings = {
   hotkey: { modifiers: 2, vkCode: 0x52 },
   hideHotkey: { modifiers: 2, vkCode: 0x48 },
   meterWidth: 400,
+  meterOpacity: MAX_METER_OPACITY,
   rowHeight: 36,
   isDebugMode: false,
   detailHeight: 600,
@@ -111,6 +117,23 @@ const defaultSettings = {
 };
 
 export const useSettingsStore = create<SettingsState>((set) => {
+  const readOptionalNumber = (value: unknown) => {
+    if (value === null || value === undefined || value === "") return null;
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : null;
+  };
+
+  const readPositiveNumber = (value: unknown, fallback: number) => {
+    const parsed = readOptionalNumber(value);
+    return parsed !== null && parsed > 0 ? parsed : fallback;
+  };
+
+  const readClampedNumber = (value: unknown, fallback: number, min: number, max: number) => {
+    const parsed = readOptionalNumber(value);
+    if (parsed === null) return fallback;
+    return Math.min(max, Math.max(min, parsed));
+  };
+
   const interval = setInterval(() => {
     const j = jb();
     if (!j || typeof j.loadProps !== "function") return;
@@ -137,10 +160,12 @@ export const useSettingsStore = create<SettingsState>((set) => {
     set({
       hotkey: parsedHotkey ?? defaultSettings.hotkey,
       hideHotkey: parsedHideHotkey ?? defaultSettings.hideHotkey,
-      meterWidth: Number(j.loadProps?.("meterWidth")) || defaultSettings.meterWidth,
-      rowHeight: Number(j.loadProps?.("rowHeight")) || defaultSettings.rowHeight,
-      detailHeight: Number(j.loadProps?.("detailHeight")) || defaultSettings.detailHeight,
-      detailWidth: Number(j.loadProps?.("detailWidth")) || defaultSettings.detailWidth,
+      meterWidth: readPositiveNumber(j.loadProps?.("meterWidth"), defaultSettings.meterWidth),
+      meterOpacity: readClampedNumber(j.loadProps?.("meterOpacity"), defaultSettings.meterOpacity,
+        MIN_METER_OPACITY, MAX_METER_OPACITY,),
+      rowHeight: readPositiveNumber(j.loadProps?.("rowHeight"), defaultSettings.rowHeight),
+      detailHeight: readPositiveNumber(j.loadProps?.("detailHeight"), defaultSettings.detailHeight),
+      detailWidth: readPositiveNumber(j.loadProps?.("detailWidth"), defaultSettings.detailWidth),
       displayMode: j.loadProps?.("displayMode") ?? defaultSettings.displayMode,
       isDebugMode: j.isDebuggingMode?.() ?? false,
       nameDisplay: j.loadProps?.("nameDisplay") ?? defaultSettings.nameDisplay,
@@ -162,6 +187,7 @@ export const useSettingsStore = create<SettingsState>((set) => {
     hideHotkey: defaultSettings.hideHotkey,
     isMinimal: defaultSettings.isMinimal,
     meterWidth: defaultSettings.meterWidth,
+    meterOpacity: defaultSettings.meterOpacity,
     rowHeight: defaultSettings.rowHeight,
     detailHeight: defaultSettings.detailHeight,
     detailWidth: defaultSettings.detailWidth,
@@ -210,6 +236,11 @@ export const useSettingsStore = create<SettingsState>((set) => {
     setMeterWidth: (meterWidth) => {
       set({ meterWidth });
       jb()?.saveProps?.("meterWidth", meterWidth);
+    },
+    setMeterOpacity: (meterOpacity) => {
+      const next = Math.min(MAX_METER_OPACITY, Math.max(MIN_METER_OPACITY, meterOpacity));
+      set({ meterOpacity: next });
+      jb()?.saveProps?.("meterOpacity", String(next));
     },
     setRowHeight: (rowHeight) => {
       set({ rowHeight });


### PR DESCRIPTION
# 미터기 게이지 투명도 옵션 추가

- 인게임 시인성 확보를 위해 미터기 게이지의 투명도 설정 옵션을 추가합니다.
<img width="582" height="572" alt="제목 없음" src="https://github.com/user-attachments/assets/703b919f-1b5b-4505-8517-41dd8f6f5437" />
<img width="1633" height="661" alt="제목 없음2" src="https://github.com/user-attachments/assets/78cb9669-1de2-48be-987d-541eaee3619e" />
<img width="401" height="287" alt="image" src="https://github.com/user-attachments/assets/3fb76f3d-d27e-4f02-9479-83804dbf14c4" />